### PR TITLE
Line comments

### DIFF
--- a/syntaxes/paexpressions.tmGrammar.json
+++ b/syntaxes/paexpressions.tmGrammar.json
@@ -18,13 +18,21 @@
     },
     {
       "include": "#comment"
+    },
+    {
+      "include": "#line-comment"
     }
   ],
   "repository": {
     "comment": {
-      "begin": "\/\\*",
-      "end": "\\*\/",
+      "begin": "/\\*",
+      "end": "\\*/",
       "name": "comment.block"
+    },
+    "line-comment": {
+      "begin": "//",
+      "end": "$",
+      "name": "comment.line.double-slash.pae"
     },
     "parameter": {
       "begin": "\\(",
@@ -66,8 +74,7 @@
         }
       },
       "name": "string.quoted.single.pae",
-      "patterns": [
-      ]
+      "patterns": []
     },
     "illegal": {
       "patterns": [

--- a/test.pae
+++ b/test.pae
@@ -13,3 +13,5 @@ arrayWithMultipleLines()?[
 ]
 doubleQuoteInsideSingleQuotes('"double_quote"')
 /* this is a comment */
+item()?['test'] // inline comment
+// some line comment


### PR DESCRIPTION
I use these pae files now for documentation, so I thought supporting line comment would also be nice.
I'm aware that the expressions as used in flow don't support comments (yet).
So having comments in pae at all might be not ideal.

would be great to have some kind of "notebook" functionality with general markdown support and its code blocks then support pae syntax highlighting?!